### PR TITLE
Fixed multi-day events are only clickable from the start

### DIFF
--- a/styles/calendar.css
+++ b/styles/calendar.css
@@ -89,3 +89,21 @@ td.fc-daygrid-day.fc-day.fc-day-today {
 .fc-timegrid-event {
   @apply px-1 !important;
 }
+
+td.fc-daygrid-day.fc-day {
+  pointer-events: none !important;
+}
+
+.fc-event {
+  pointer-events: all !important;
+  cursor: pointer !important;
+  z-index: 10 !important;
+}
+
+.fc-daygrid-event-harness {
+  pointer-events: all !important;
+}
+
+.fc-daygrid-day-top {
+  pointer-events: none !important;
+}


### PR DESCRIPTION
This pull request includes changes to the `styles/calendar.css` file to improve the interactivity and visual behavior of calendar events. The most important changes include disabling pointer events for certain elements and ensuring that calendar events are interactive.

Changes to interactivity and visual behavior

* [`styles/calendar.css`](diffhunk://#diff-3dfc939a9f70b8f25d42bf4303b7f0da61dd7cafb260d17293b63ae990d59460R92-R109): Disabled pointer events for `td.fc-daygrid-day.fc-day` and `.fc-daygrid-day-top` to prevent interactions with these elements.
* [`styles/calendar.css`](diffhunk://#diff-3dfc939a9f70b8f25d42bf4303b7f0da61dd7cafb260d17293b63ae990d59460R92-R109): Enabled pointer events for `.fc-event` and `.fc-daygrid-event-harness` to ensure that calendar events are interactive and can be clicked.
* [`styles/calendar.css`](diffhunk://#diff-3dfc939a9f70b8f25d42bf4303b7f0da61dd7cafb260d17293b63ae990d59460R92-R109): Added a cursor pointer and increased z-index for `.fc-event` to improve the visual indication of interactivity.

# Before

![pr4](https://github.com/user-attachments/assets/9e23d231-3778-42bc-9f7b-496d430c4c88)

# After

![pr3](https://github.com/user-attachments/assets/abc5057a-b987-4027-806c-690126a73394)
