### PR TITLE
Fixed month view current month dropdown incorrect

### DIFF
--- a/components/calendar.tsx
+++ b/components/calendar.tsx
@@ -253,7 +253,7 @@ export default function Calendar() {
           eventClick={(eventInfo) => handleEventClick(eventInfo)}
           eventChange={(eventInfo) => handleEventChange(eventInfo)}
           select={handleDateSelect}
-          datesSet={(dates) => setViewedDate(dates.start)}
+          datesSet={(dates) => setViewedDate(dates.view.currentStart)}
           dateClick={() => setEventAddOpen(true)}
           nowIndicator
           editable


### PR DESCRIPTION
This pull request includes a small change to the `components/calendar.tsx` file. The change modifies the `datesSet` function to use `dates.view.currentStart` instead of `dates.start` to set the viewed date.

* [`components/calendar.tsx`](diffhunk://#diff-c54df630ffcfc42f5e43bdf356e1be322dfb63ecef8e4be5dd4ec335cf073eeaL256-R256): Changed the `datesSet` function to use `dates.view.currentStart` instead of `dates.start` for setting the viewed date.

# Before

![pr6](https://github.com/user-attachments/assets/e5eafc67-3c46-4dc3-80a2-d249bb20d775)

# After

![pr5](https://github.com/user-attachments/assets/4a009f52-a20e-43bc-b5aa-a4fd46c8d4d0)

